### PR TITLE
changed ordering of select lists in admin

### DIFF
--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -28,7 +28,7 @@ class PersonPersonInline(admin.TabularInline):
 class SlGenericAdminView(admin.ModelAdmin):
     list_display = ('name', 'description')
     search_fields = ('name', 'description')
-    ordering = ('id',)
+    ordering = ('name',)
 
 
 class LetterAdminView(admin.ModelAdmin):


### PR DESCRIPTION
Select lists in admin need were set to order by Id field, but researcher requested to order by name, as it's easier for them to find values in select lists in forms