### PR TITLE
better handling of relationships in the admin

### DIFF
--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -11,6 +11,9 @@ admin.site.site_header = 'Material Identities, Social Bodies: Admin Dashboard'
 # Functions
 
 def fk_link(link_url, link_label):
+    """
+    Take a URL and a label and generate a link for foreign key fields in admin lists
+    """
     if link_label is not None:
         return mark_safe('<a href="{}">{}</a>'.format(link_url, link_label))
     else:
@@ -128,17 +131,22 @@ class LetterPersonAdminView(admin.ModelAdmin):
                          'state')
 
     def letter_link(self, letterperson):
+        """
+        Make the Letter FK reference in the list_display a clickable link, rather than plain text
+        """
         url = reverse("admin:researchdata_letter_change", args=[letterperson.letter.id])
         return fk_link(url, letterperson.letter)
     letter_link.short_description = 'Letter'
 
     def person_link(self, letterperson):
+        """
+        Make the Person FK reference in the list_display a clickable link, rather than plain text
+        """
         if letterperson.person is None:
             return '-'
         else:
             url = reverse("admin:researchdata_person_change", args=[letterperson.person.id])
             return fk_link(url, letterperson.person)
-
     person_link.short_description = 'Person'
 
     def save_model(self, request, obj, form, change):
@@ -150,7 +158,6 @@ class LetterPersonAdminView(admin.ModelAdmin):
             obj.created_by = request.user
         obj.lastupdated_by = request.user
         obj.save()
-
 
 
 class PersonAdminView(admin.ModelAdmin):
@@ -193,14 +200,21 @@ class M2MLetterLetterAdminView(admin.ModelAdmin):
     ordering = ('-id',)
 
     def letter_1_link(self, letterperson):
+        """
+        Make the Letter 1 FK reference in the list_display a clickable link, rather than plain text
+        """
         url = reverse("admin:researchdata_letter_change", args=[letterperson.letter_1.id])
         return fk_link(url, letterperson.letter_1)
     letter_1_link.short_description = 'Letter (1)'
-    
+
     def letter_2_link(self, letterperson):
+        """
+        Make the Letter 2 FK reference in the list_display a clickable link, rather than plain text
+        """
         url = reverse("admin:researchdata_letter_change", args=[letterperson.letter_2.id])
         return fk_link(url, letterperson.letter_2)
     letter_2_link.short_description = 'Letter (2)'
+
 
 class M2MPersonPersonAdminView(admin.ModelAdmin):
     """
@@ -212,11 +226,17 @@ class M2MPersonPersonAdminView(admin.ModelAdmin):
     ordering = ('-id',)
 
     def person_1_link(self, letterperson):
+        """
+        Make the Person 1 FK reference in the list_display a clickable link, rather than plain text
+        """
         url = reverse("admin:researchdata_person_change", args=[letterperson.person_1.id])
         return fk_link(url, letterperson.person_1)
     person_1_link.short_description = 'Person (1)'
 
     def person_2_link(self, letterperson):
+        """
+        Make the Person 2 FK reference in the list_display a clickable link, rather than plain text
+        """
         url = reverse("admin:researchdata_person_change", args=[letterperson.person_2.id])
         return fk_link(url, letterperson.person_2)
     person_2_link.short_description = 'Person (2)'

--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -1,9 +1,20 @@
 from django.contrib import admin
+from django.urls import reverse
 from django_admin_listfilter_dropdown.filters import RelatedDropdownFilter
+from django.utils.safestring import mark_safe
 from . import models
 
 # Set the title of the dashboard
 admin.site.site_header = 'Material Identities, Social Bodies: Admin Dashboard'
+
+
+# Functions
+
+def fk_link(link_url, link_label):
+    if link_label is not None:
+        return mark_safe('<a href="{}">{}</a>'.format(link_url, link_label))
+    else:
+        return '-'
 
 
 # Inlines
@@ -12,12 +23,22 @@ class LetterLetterImageInline(admin.TabularInline):
     model = models.LetterImage
 
 
-class LetterLetterInline(admin.TabularInline):
+class LetterLetter1Inline(admin.TabularInline):
+    model = models.Letter.letter.through
+    fk_name = "letter_2"
+
+
+class LetterLetter2Inline(admin.TabularInline):
     model = models.Letter.letter.through
     fk_name = "letter_1"
 
 
-class PersonPersonInline(admin.TabularInline):
+class PersonPerson1Inline(admin.TabularInline):
+    model = models.Person.person.through
+    fk_name = "person_2"
+
+
+class PersonPerson2Inline(admin.TabularInline):
     model = models.Person.person.through
     fk_name = "person_1"
 
@@ -44,7 +65,7 @@ class LetterAdminView(admin.ModelAdmin):
                    ('estimated_proportion_of_letter', RelatedDropdownFilter))
     search_fields = ('title', 'summary', 'transcription_plain', 'transcription_normalized')
     ordering = ('-id',)
-    inlines = [LetterLetterImageInline, LetterLetterInline]
+    inlines = [LetterLetterImageInline, LetterLetter1Inline, LetterLetter2Inline]
     readonly_fields = ('created_by', 'created_datetime', 'lastupdated_by', 'lastupdated_datetime')
     filter_horizontal = ('letter_type', 'commentary', 'location')
 
@@ -64,13 +85,11 @@ class LetterPersonAdminView(admin.ModelAdmin):
     Customise the Letter Person section of the Django admin
     """
     list_display = ('id',
-                    'letter',
-                    'person',
+                    'letter_link',
+                    'person_link',
                     'person_other',
                     'person_letter_relationship')
-    list_filter = ('letter',
-                   'person',
-                   ('person_letter_relationship', RelatedDropdownFilter),
+    list_filter = (('person_letter_relationship', RelatedDropdownFilter),
                    ('body_part', RelatedDropdownFilter),
                    ('bodily_activity', RelatedDropdownFilter),
                    ('appearance', RelatedDropdownFilter),
@@ -83,7 +102,9 @@ class LetterPersonAdminView(admin.ModelAdmin):
                    ('treatment', RelatedDropdownFilter),
                    ('context', RelatedDropdownFilter),
                    ('roles', RelatedDropdownFilter),
-                   ('state', RelatedDropdownFilter))
+                   ('state', RelatedDropdownFilter),
+                   'letter',
+                   'person')
     search_fields = ('letter__title',
                      'person__first_name',
                      'person__last_name',
@@ -106,6 +127,20 @@ class LetterPersonAdminView(admin.ModelAdmin):
                          'roles',
                          'state')
 
+    def letter_link(self, letterperson):
+        url = reverse("admin:researchdata_letter_change", args=[letterperson.letter.id])
+        return fk_link(url, letterperson.letter)
+    letter_link.short_description = 'Letter'
+
+    def person_link(self, letterperson):
+        if letterperson.person is None:
+            return '-'
+        else:
+            url = reverse("admin:researchdata_person_change", args=[letterperson.person.id])
+            return fk_link(url, letterperson.person)
+
+    person_link.short_description = 'Person'
+
     def save_model(self, request, obj, form, change):
         """
         Override default save_model, by adding values to automated fields
@@ -115,6 +150,7 @@ class LetterPersonAdminView(admin.ModelAdmin):
             obj.created_by = request.user
         obj.lastupdated_by = request.user
         obj.save()
+
 
 
 class PersonAdminView(admin.ModelAdmin):
@@ -130,7 +166,7 @@ class PersonAdminView(admin.ModelAdmin):
                    ('rank', RelatedDropdownFilter))
     search_fields = ('first_name', 'middle_name', 'last_name')
     ordering = ('-id',)
-    inlines = [PersonPersonInline]
+    inlines = [PersonPerson1Inline, PersonPerson2Inline]
     readonly_fields = ('created_by', 'created_datetime', 'lastupdated_by', 'lastupdated_datetime')
     filter_horizontal = ('title', 'marital_status', 'religion', 'rank')
 
@@ -149,20 +185,41 @@ class M2MLetterLetterAdminView(admin.ModelAdmin):
     """
     Customise the M2M Letter <-> Letter section of the Django admin
     """
-    list_display = ('id', 'letter_1', 'letter_2', 'relationship_type')
-    list_filter = ('relationship_type',)
+    list_display = ('id', 'letter_1_link', 'letter_2_link', 'relationship_type')
+    list_filter = (('relationship_type', RelatedDropdownFilter),
+                   ('letter_1', RelatedDropdownFilter),
+                   ('letter_2', RelatedDropdownFilter))
     search_fields = ('letter_1', 'letter_2', 'relationship_type')
     ordering = ('-id',)
 
+    def letter_1_link(self, letterperson):
+        url = reverse("admin:researchdata_letter_change", args=[letterperson.letter_1.id])
+        return fk_link(url, letterperson.letter_1)
+    letter_1_link.short_description = 'Letter (1)'
+    
+    def letter_2_link(self, letterperson):
+        url = reverse("admin:researchdata_letter_change", args=[letterperson.letter_2.id])
+        return fk_link(url, letterperson.letter_2)
+    letter_2_link.short_description = 'Letter (2)'
 
 class M2MPersonPersonAdminView(admin.ModelAdmin):
     """
     Customise the M2M Person <-> Person section of the Django admin
     """
-    list_display = ('id', 'person_1', 'person_2', 'relationship_type')
+    list_display = ('id', 'person_1_link', 'person_2_link', 'relationship_type')
     list_filter = ('relationship_type',)
     search_fields = ('person_1', 'person_2', 'relationship_type')
     ordering = ('-id',)
+
+    def person_1_link(self, letterperson):
+        url = reverse("admin:researchdata_person_change", args=[letterperson.person_1.id])
+        return fk_link(url, letterperson.person_1)
+    person_1_link.short_description = 'Person (1)'
+
+    def person_2_link(self, letterperson):
+        url = reverse("admin:researchdata_person_change", args=[letterperson.person_2.id])
+        return fk_link(url, letterperson.person_2)
+    person_2_link.short_description = 'Person (2)'
 
 
 # Register classes


### PR DESCRIPTION
Karen asked for a few changesv in admin dashboard:

- To change foreign key objects in lists to clickable links to the related object. Strangely this isn't a simple option, but found a way to do it through this article: <https://avilpage.com/2017/11/django-tips-tricks-hyperlink-foreignkey-admin.html>
- To include inline M2M relationships in both directions