### PR TITLE
improved linebreaks for transcripts

### DIFF
--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -290,8 +290,6 @@ class Letter(models.Model):
             if thumbnail:
                 return thumbnail.url
 
-        return None
-
     @property
     def list_title(self):
         return textwrap.shorten(self.title, width=90, placeholder="...")

--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -20,6 +20,14 @@ def singular_plural(count, word_singular, word_plural=None):
     return f'{count} {word_singular}' if count == 1 else f'{count} {word_plural}'
 
 
+def process_transcription(transcription):
+        """
+        Processes provided transcription to appear on the public interface
+        """
+        # Add <br> for linebreaks instead of the <p> that the linebreaks template filter adds
+        return transcription.replace('\n', '<br>')
+
+
 # Select List models
 
 
@@ -284,9 +292,21 @@ class Letter(models.Model):
     lastupdated_datetime = models.DateTimeField(auto_now=True, verbose_name="Last Updated")
 
     @property
+    def transcription_plain_processed(self):
+        return process_transcription(self.transcription_plain)
+
+    @property
+    def transcription_normalized_processed(self):
+        return process_transcription(self.transcription_normalized)
+
+    @property
     def list_image_url(self):
         if self.letterimage_set.all():
-            return self.letterimage_set.all()[0].image_thumbnail.url
+            thumbnail = self.letterimage_set.all()[0].image_thumbnail
+            if thumbnail:
+                return thumbnail.url
+
+        return None
 
     @property
     def list_title(self):

--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -21,11 +21,11 @@ def singular_plural(count, word_singular, word_plural=None):
 
 
 def process_transcription(transcription):
-        """
-        Processes provided transcription to appear on the public interface
-        """
-        # Add <br> for linebreaks instead of the <p> that the linebreaks template filter adds
-        return transcription.replace('\n', '<br>')
+    """
+    Processes provided transcription to appear on the public interface
+    """
+    # Add <br> for linebreaks instead of the <p> that the linebreaks template filter adds
+    return transcription.replace('\n', '<br>')
 
 
 # Select List models

--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -20,14 +20,6 @@ def singular_plural(count, word_singular, word_plural=None):
     return f'{count} {word_singular}' if count == 1 else f'{count} {word_plural}'
 
 
-def process_transcription(transcription):
-    """
-    Processes provided transcription to appear on the public interface
-    """
-    # Add <br> for linebreaks instead of the <p> that the linebreaks template filter adds
-    return transcription.replace('\n', '<br>')
-
-
 # Select List models
 
 
@@ -290,14 +282,6 @@ class Letter(models.Model):
     lastupdated_by = models.ForeignKey(User, related_name="letter_lastupdated_by",
                                        on_delete=models.PROTECT, blank=True, null=True, verbose_name="Last Updated By")
     lastupdated_datetime = models.DateTimeField(auto_now=True, verbose_name="Last Updated")
-
-    @property
-    def transcription_plain_processed(self):
-        return process_transcription(self.transcription_plain)
-
-    @property
-    def transcription_normalized_processed(self):
-        return process_transcription(self.transcription_normalized)
 
     @property
     def list_image_url(self):

--- a/django/researchdata/templates/researchdata/detail-letter.html
+++ b/django/researchdata/templates/researchdata/detail-letter.html
@@ -42,11 +42,11 @@
             </div>
             <!-- Transcription Text: Plain -->
             <div id="transcription-texts-text-plain" class="transcription-texts-text">
-                {{ letter.transcription_plain_processed | safe }}
+                {{ letter.transcription_plain | safe | linebreaksbr }}
             </div>
             <!-- Transcription Text: Normalized -->
             <div id="transcription-texts-text-normalized" class="transcription-texts-text">
-                {{ letter.transcription_normalized_processed | safe }}
+                {{ letter.transcription_normalized | safe | linebreaksbr }}
             </div>
         </div>
 

--- a/django/researchdata/templates/researchdata/detail-letter.html
+++ b/django/researchdata/templates/researchdata/detail-letter.html
@@ -42,11 +42,11 @@
             </div>
             <!-- Transcription Text: Plain -->
             <div id="transcription-texts-text-plain" class="transcription-texts-text">
-                {{ letter.transcription_plain | safe | linebreaks }}
+                {{ letter.transcription_plain_processed | safe }}
             </div>
             <!-- Transcription Text: Normalized -->
             <div id="transcription-texts-text-normalized" class="transcription-texts-text">
-                {{ letter.transcription_normalized | safe | linebreaks }}
+                {{ letter.transcription_normalized_processed | safe }}
             </div>
         </div>
 


### PR DESCRIPTION
The default linebreaks template filter creates `<p>` tags instead of `<br>` tags, which causes the text to lose linebreaks when copying and pasting as RTF into Word, meaning the researchers had to manually enter line breaks (which is very time consuming).